### PR TITLE
V1.2.20 reduce size

### DIFF
--- a/3.7-stretch/Dockerfile
+++ b/3.7-stretch/Dockerfile
@@ -33,7 +33,7 @@ RUN PYENV_VERSION="v1.2.20" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE:　pyenv install  does not include the system version 3.7.9.
+# NOTE: pyenv install does not include the system version 3.7.9.
 # System version 3.7.9. uses a symbolic link in /usr/local/.
 RUN for VER in "3.6.12" "3.7.9" "3.8.6" "3.9.0"; \
     do \
@@ -43,8 +43,7 @@ RUN for VER in "3.6.12" "3.7.9" "3.8.6" "3.9.0"; \
         pyenv install $VER ; \
       fi \
       && PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" \
-      && pyenv rehash \
-      && rm -rf ${PYENV_ROOT}/versions/${VER}/lib/python3.*/test ; \
+      && pyenv rehash ; \
     done \
     && pyenv global system $(pyenv versions --bare | sort -rV | xargs)
 

--- a/3.7-stretch/Dockerfile
+++ b/3.7-stretch/Dockerfile
@@ -33,11 +33,18 @@ RUN PYENV_VERSION="v1.2.20" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
+# NOTE:　pyenv install  does not include the system version 3.7.9.
+# System version 3.7.9. uses a symbolic link in /usr/local/.
 RUN for VER in "3.6.12" "3.7.9" "3.8.6" "3.9.0"; \
     do \
-      pyenv install $VER ; \
-      PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" ; \
-      pyenv rehash ; \
+      if [ "$VER" = "3.7.9" ] ; then \
+        ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}"; \
+      else \
+        pyenv install $VER ; \
+      fi \
+      && PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" \
+      && pyenv rehash \
+      && rm -rf ${PYENV_ROOT}/versions/${VER}/lib/python3.*/test ; \
     done \
     && pyenv global system $(pyenv versions --bare | sort -rV | xargs)
 


### PR DESCRIPTION
データサイズ削減の為、`/opt/pyenv/versions` のシステムバージョン(3.7.9)をシンボリックで利用するように変更しました。

test packageは削除しないように対応しました。
https://github.com/tractrix/codelift-plugins/issues/1724#issuecomment-727656095

docker imageは `conchoid/docker-pyenv:v1.2.20-2-3.7-stretch`のタグ名でdocker hubへpushしました。