### PR TITLE
Update pyenv to v1.2.21

### DIFF
--- a/3.7-stretch/Dockerfile
+++ b/3.7-stretch/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN PYENV_VERSION="v1.2.20" \
+RUN PYENV_VERSION="v1.2.21" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \


### PR DESCRIPTION
pyenvを `v1.2.21`に更新しました。

docker imageは `conchoid/docker-pyenv:v1.2.21-1-3.7-stretch`のタグ名でdocker hubへpushしました。

関連するPR
https://github.com/tractrix/tractrix-plugins/pull/142