### PR TITLE
Fixed to add six modules

### DIFF
--- a/3.7-buster/Dockerfile
+++ b/3.7-buster/Dockerfile
@@ -47,7 +47,7 @@ RUN for VER in "3.6.12" "3.7.9" "3.8.6" "3.9.0"; \
       else \
         pyenv install $VER ; \
       fi \
-      && PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" \
+      && PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" six \
       && pyenv rehash ; \
     done \
     && pyenv global system $(pyenv versions --bare | sort -rV | xargs)

--- a/3.7-stretch/Dockerfile
+++ b/3.7-stretch/Dockerfile
@@ -42,7 +42,7 @@ RUN for VER in "3.6.12" "3.7.9" "3.8.6" "3.9.0"; \
       else \
         pyenv install $VER ; \
       fi \
-      && PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" \
+      && PYENV_VERSION="$VER" pip install --upgrade pip=="$PYTHON_PIP_VERSION" six \
       && pyenv rehash ; \
     done \
     && pyenv global system $(pyenv versions --bare | sort -rV | xargs)


### PR DESCRIPTION
v1.2.17-1-3.7-stretch以降、sixが含まれなくなっていたのでsixモジュールを追加しました。
(python2系と3系の互換ライブラリで容量が10KB程度なのでこちらに追加しました。)

docker hubには以下のタグ名でpushしています。

conchoid/docker-pyenv:v1.2.21-3-3.7-stretch
conchoid/docker-pyenv:v1.2.21-3-3.7-buster

関連するIssue
https://github.com/tractrix/codelift-plugins/issues/1819#issuecomment-793407444

関連するPR
https://github.com/tractrix/tractrix-plugins/pull/161