### PR TITLE
V2.2.2 3 3.8 buster poetry update

### DIFF
--- a/3.8-buster/Dockerfile
+++ b/3.8-buster/Dockerfile
@@ -51,7 +51,8 @@ RUN for VER in "3.6.15" "3.7.12" "3.8.12" "3.9.9" "3.10.1"; \
     do \
       if [ "$VER" = "3.6.15" ] ; then \
         pyenv install $VER \
-        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP20_VERSION" six poetry=="$ROCRO_POETRY115_VERSION"; \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP20_VERSION" \
+        && PYENV_VERSION="$VER" pip install poetry=="$ROCRO_POETRY115_VERSION"; \
       elif [ "$VER" = "3.8.12" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \


### PR DESCRIPTION
V2.2.2-3タグに対して修正を行なっています。

python3.6.15の場合に`poetry==1.1.5`をインストールしていますが、`pip install --upgrade`を行うことで
バージョンのconflictが発生していましたので、pipに関しては`pip install --upgrade` を利用して
poetryに関しては`pip install `を実施することでFailしないように修正しました。`six`に関してはpoetryインストール時に
インストールされるので、このバージョンでは指定しないように変更しています。

DockerHubには下記タグでPushしています。
conchoid/docker-pyenv:v2.2.2-3-3.8-buster

下記を先にマージお願いします。
https://github.com/conchoid/docker-pyenv/pull/17 (Update PIP and Poetry Version #17)