### PR TITLE
Add python3.11 in pyenv

### DIFF
--- a/3.10-bullseye/Dockerfile
+++ b/3.10-bullseye/Dockerfile
@@ -1,0 +1,62 @@
+FROM python:3.10.12-slim-bullseye
+
+ENV PYENV_ROOT /opt/pyenv
+ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+      gcc-10 g++-10 make build-essential zlib1g-dev libbz2-dev \
+      libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
+      locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
+    && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
+    && rm -f /etc/apt/sources.list.d/bionic-security.list
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
+ENV ROCRO_POETRY_VERSION="1.5.1"
+
+RUN PYENV_VERSION="v2.3.21" \
+    && mkdir -p "$PYENV_ROOT" \
+    && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
+    && cd "$PYENV_ROOT" \
+    && git checkout -q "$PYENV_VERSION" \
+    && PYTHON_BUILD_VERSION="1874f95a0eba3479dcd51faf7e8cd44b12446b6f" \
+    && cd "$PYENV_ROOT/plugins" \
+    && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
+    && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
+    && PYENV_PIP_MIGRATE_DIR="$PYENV_ROOT/plugins/pyenv-pip-migrate" \
+    && git clone https://github.com/pyenv/pyenv-pip-migrate.git "$PYENV_PIP_MIGRATE_DIR" \
+    && cd "$PYENV_PIP_MIGRATE_DIR" \
+    && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
+    && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
+
+
+# NOTE: pyenv install does not include the system version 3.10.12.
+# System version 3.10.12. uses a symbolic link in /usr/local/.
+# Python 3.10.12 required OpenSSL 1.1.1
+RUN for VER in "3.7.17" "3.8.17" "3.9.17" "3.10.12" "3.11.4"; \
+    do \
+      if [ "$VER" = "3.10.12" ] ; then \
+        ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      elif [ "$VER" = "3.11.4" ] ; then \
+        apt-get update && apt-get install -y libssl-dev \
+        && pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      else \
+        pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      fi \
+      && pyenv rehash ; \
+    done \
+    && pyenv global system $(pyenv versions --bare | sort -rV | xargs)
+
+#RUN [ $(pyenv versions --bare | wc -l) -eq 5 ]

--- a/3.10-buster/Dockerfile
+++ b/3.10-buster/Dockerfile
@@ -1,0 +1,70 @@
+FROM python:3.10.12-slim-buster
+
+ENV PYENV_ROOT /opt/pyenv
+ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+      gcc-7 g++-7 make build-essential zlib1g-dev libbz2-dev \
+      libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+      xz-utils zlib1g-dbg unixodbc-dev tk-dev libffi-dev liblzma-dev python-openssl git gnupg \
+      locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-7
+
+RUN echo "deb http://ftp.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
+    && apt-get install -y -t bullseye-backports git-lfs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
+    && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
+    && rm -f /etc/apt/sources.list.d/bionic-security.list
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
+ENV ROCRO_POETRY_VERSION="1.5.1"
+
+RUN PYENV_VERSION="v2.3.21" \
+    && mkdir -p "$PYENV_ROOT" \
+    && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
+    && cd "$PYENV_ROOT" \
+    && git checkout -q "$PYENV_VERSION" \
+    && PYTHON_BUILD_VERSION="1874f95a0eba3479dcd51faf7e8cd44b12446b6f" \
+    && cd "$PYENV_ROOT/plugins" \
+    && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
+    && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
+    && PYENV_PIP_MIGRATE_DIR="$PYENV_ROOT/plugins/pyenv-pip-migrate" \
+    && git clone https://github.com/pyenv/pyenv-pip-migrate.git "$PYENV_PIP_MIGRATE_DIR" \
+    && cd "$PYENV_PIP_MIGRATE_DIR" \
+    && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
+    && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
+
+
+# NOTE: pyenv install does not include the system version 3.10.12.
+# System version 3.10.12. uses a symbolic link in /usr/local/.
+# Python 3.10.12 required OpenSSL 1.1.1
+RUN for VER in "3.7.17" "3.8.17" "3.9.17" "3.10.12" "3.11.4"; \
+    do \
+      if [ "$VER" = "3.10.12" ] ; then \
+        ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      elif [ "$VER" = "3.11.4" ] ; then \
+        apt-get update && apt-get install -y libssl-dev \
+        && pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      else \
+        pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      fi \
+      && pyenv rehash ; \
+    done \
+    && pyenv global system $(pyenv versions --bare | sort -rV | xargs)
+
+#RUN [ $(pyenv versions --bare | wc -l) -eq 5 ]


### PR DESCRIPTION
python 3.10のベースイメージに対してruntime  python 3.11を追加。

docker hubには下記のタグでpush済。
`conchoid/docker-pyenv:v2.3.21-1-3.10-bullseye`
`conchoid/docker-pyenv:v2.3.21-1-3.10-buster`