### PR TITLE
Support python 3.12

### DIFF
--- a/3.11-bookworm/Dockerfile
+++ b/3.11-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.9-slim-bookworm
+FROM python:3.11.10-slim-bookworm
 
 ENV PYENV_ROOT /opt/pyenv
 ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -23,12 +23,12 @@ ENV LC_ALL en_US.UTF-8
 ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
 ENV ROCRO_POETRY_VERSION="1.5.1"
 
-RUN PYENV_VERSION="v2.4.4" \
+RUN PYENV_VERSION="v2.4.15" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="d660c5a84f6b03a94961eb0e49adb2b25cd091b1" \
+    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -38,16 +38,15 @@ RUN PYENV_VERSION="v2.4.4" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE: pyenv install does not include the system version 3.11.9.
-# System version 3.11.9. uses a symbolic link in /usr/local/.
-# Python 3.11.9 required OpenSSL 1.1.1
-RUN for VER in "3.7.17" "3.8.19" "3.9.19" "3.10.14" "3.11.9" "3.12.2"; \
+# NOTE: pyenv install does not include the system version 3.11.10.
+# System version 3.11.10. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
     do \
-      if [ "$VER" = "3.11.9" ]  ; then \
+      if [ "$VER" = "3.11.10" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.14" ] || [ "$VER" = "3.12.2" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ] || [ "$VER" = "3.13.0" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.11-bullseye/Dockerfile
+++ b/3.11-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.9-slim-bullseye
+FROM python:3.11.10-slim-bullseye
 
 ENV PYENV_ROOT /opt/pyenv
 ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -23,12 +23,12 @@ ENV LC_ALL en_US.UTF-8
 ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
 ENV ROCRO_POETRY_VERSION="1.5.1"
 
-RUN PYENV_VERSION="v2.4.4" \
+RUN PYENV_VERSION="v2.4.15" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="d660c5a84f6b03a94961eb0e49adb2b25cd091b1" \
+    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -38,16 +38,15 @@ RUN PYENV_VERSION="v2.4.4" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE: pyenv install does not include the system version 3.11.9.
-# System version 3.11.9. uses a symbolic link in /usr/local/.
-# Python 3.10.14 required OpenSSL 1.1.1
-RUN for VER in "3.7.17" "3.8.19" "3.9.19" "3.10.14" "3.11.9" "3.12.2"; \
+# NOTE: pyenv install does not include the system version 3.11.10.
+# System version 3.11.10. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
     do \
-      if [ "$VER" = "3.11.9" ]  ; then \
+      if [ "$VER" = "3.11.10" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.14" ] || [ "$VER" = "3.12.2" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ] || [ "$VER" = "3.13.0" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
@@ -58,4 +57,3 @@ RUN for VER in "3.7.17" "3.8.19" "3.9.19" "3.10.14" "3.11.9" "3.12.2"; \
       && pyenv rehash ; \
     done \
     && pyenv global system $(pyenv versions --bare | sort -rV | xargs)
-

--- a/3.11-buster/Dockerfile
+++ b/3.11-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM conchoid/debian-buster:python-3.11.9
+FROM conchoid/debian-buster:python-3.11.10
 
 ENV PYENV_ROOT /opt/pyenv
 ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -14,12 +14,12 @@ ENV LC_ALL en_US.UTF-8
 ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
 ENV ROCRO_POETRY_VERSION="1.5.1"
 
-RUN PYENV_VERSION="v2.4.4" \
+RUN PYENV_VERSION="v2.4.15" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="d660c5a84f6b03a94961eb0e49adb2b25cd091b1" \
+    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -29,16 +29,15 @@ RUN PYENV_VERSION="v2.4.4" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE: pyenv install does not include the system version 3.11.9.
-# System version 3.11.9. uses a symbolic link in /usr/local/.
-# Python 3.10.14 required OpenSSL 1.1.1
-RUN for VER in "3.7.17" "3.8.19" "3.9.19" "3.10.14" "3.11.9" "3.12.2"; \
+# NOTE: pyenv install does not include the system version 3.11.10.
+# System version 3.11.10. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
     do \
-      if [ "$VER" = "3.11.9" ]  ; then \
+      if [ "$VER" = "3.11.10" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.14" ] || [ "$VER" = "3.12.2" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ] || [ "$VER" = "3.13.0" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.12-bookworm/Dockerfile
+++ b/3.12-bookworm/Dockerfile
@@ -1,0 +1,60 @@
+FROM python:3.12.7-slim-bookworm
+
+ENV PYENV_ROOT /opt/pyenv
+ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+      gcc g++ make build-essential zlib1g-dev libbz2-dev \
+      libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
+      locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
+    && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
+    && rm -f /etc/apt/sources.list.d/bionic-security.list
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
+ENV ROCRO_POETRY_VERSION="1.5.1"
+
+RUN PYENV_VERSION="v2.4.13" \
+    && mkdir -p "$PYENV_ROOT" \
+    && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
+    && cd "$PYENV_ROOT" \
+    && git checkout -q "$PYENV_VERSION" \
+    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && cd "$PYENV_ROOT/plugins" \
+    && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
+    && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
+    && PYENV_PIP_MIGRATE_DIR="$PYENV_ROOT/plugins/pyenv-pip-migrate" \
+    && git clone https://github.com/pyenv/pyenv-pip-migrate.git "$PYENV_PIP_MIGRATE_DIR" \
+    && cd "$PYENV_PIP_MIGRATE_DIR" \
+    && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
+    && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
+
+# NOTE: pyenv install does not include the system version 3.11.10.
+# System version 3.11.10. uses a symbolic link in /usr/local/.
+# Python 3.11.10 required OpenSSL 1.1.1
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
+    do \
+      if [ "$VER" = "3.11.10" ]  ; then \
+        ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
+        && apt-get update && apt-get install -y libssl-dev \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ]; then \
+        apt-get update && apt-get install -y libssl-dev \
+        && pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      else \
+        pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      fi \
+      && pyenv rehash ; \
+    done \
+    && pyenv global system $(pyenv versions --bare | sort -rV | xargs)

--- a/3.12-bullseye/Dockerfile
+++ b/3.12-bullseye/Dockerfile
@@ -1,0 +1,60 @@
+FROM python:3.12.7-slim-bullseye
+
+ENV PYENV_ROOT /opt/pyenv
+ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN apt-get update \
+    && apt-get install -y --allow-unauthenticated \
+      gcc-10 g++-10 make build-essential zlib1g-dev libbz2-dev \
+      libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
+      locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
+    && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
+    && rm -f /etc/apt/sources.list.d/bionic-security.list
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
+ENV ROCRO_POETRY_VERSION="1.5.1"
+
+RUN PYENV_VERSION="v2.4.13" \
+    && mkdir -p "$PYENV_ROOT" \
+    && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
+    && cd "$PYENV_ROOT" \
+    && git checkout -q "$PYENV_VERSION" \
+    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && cd "$PYENV_ROOT/plugins" \
+    && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
+    && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
+    && PYENV_PIP_MIGRATE_DIR="$PYENV_ROOT/plugins/pyenv-pip-migrate" \
+    && git clone https://github.com/pyenv/pyenv-pip-migrate.git "$PYENV_PIP_MIGRATE_DIR" \
+    && cd "$PYENV_PIP_MIGRATE_DIR" \
+    && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
+    && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
+
+# NOTE: pyenv install does not include the system version 3.11.10.
+# System version 3.11.10. uses a symbolic link in /usr/local/.
+# Python 3.11.10 required OpenSSL 1.1.1
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
+    do \
+      if [ "$VER" = "3.11.10" ]  ; then \
+        ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
+        && apt-get update && apt-get install -y libssl-dev \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ]; then \
+        apt-get update && apt-get install -y libssl-dev \
+        && pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      else \
+        pyenv install $VER \
+        && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
+      fi \
+      && pyenv rehash ; \
+    done \
+    && pyenv global system $(pyenv versions --bare | sort -rV | xargs)

--- a/3.12-bullseye/Dockerfile
+++ b/3.12-bullseye/Dockerfile
@@ -38,16 +38,15 @@ RUN PYENV_VERSION="v2.4.13" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE: pyenv install does not include the system version 3.11.10.
-# System version 3.11.10. uses a symbolic link in /usr/local/.
-# Python 3.11.10 required OpenSSL 1.1.1
+# NOTE: pyenv install does not include the system version 3.12.7.
+# System version 3.12.7. uses a symbolic link in /usr/local/.
 RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
     do \
-      if [ "$VER" = "3.11.10" ]  ; then \
+      if [ "$VER" = "3.12.7" ]  ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.11.10" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.13-bookworm/Dockerfile
+++ b/3.13-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7-slim-bookworm
+FROM python:3.13.0-slim-bookworm
 
 ENV PYENV_ROOT /opt/pyenv
 ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -28,7 +28,7 @@ RUN PYENV_VERSION="v2.4.13" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && PYTHON_BUILD_VERSION="6a7ecfe4092f523217e9b4a5c0026e51f8dba810" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -38,15 +38,15 @@ RUN PYENV_VERSION="v2.4.13" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE: pyenv install does not include the system version 3.12.7.
-# System version 3.12.7. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
+# NOTE: pyenv install does not include the system version 3.13.0.
+# System version 3.13.0. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
     do \
-      if [ "$VER" = "3.12.7" ]  ; then \
+      if [ "$VER" = "3.13.0" ]  ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.11.10" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.11.10" ] || [ "$VER" = "3.12.7" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.13-bullseye/Dockerfile
+++ b/3.13-bullseye/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.12.7-slim-bookworm
+FROM python:3.13.0-slim-bullseye
 
 ENV PYENV_ROOT /opt/pyenv
 ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
-      gcc g++ make build-essential zlib1g-dev libbz2-dev \
+      gcc-10 g++-10 make build-essential zlib1g-dev libbz2-dev \
       libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
       xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
       locales \
@@ -28,7 +28,7 @@ RUN PYENV_VERSION="v2.4.13" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && PYTHON_BUILD_VERSION="6a7ecfe4092f523217e9b4a5c0026e51f8dba810" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -38,15 +38,15 @@ RUN PYENV_VERSION="v2.4.13" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
     && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
 
-# NOTE: pyenv install does not include the system version 3.12.7.
-# System version 3.12.7. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
+# NOTE: pyenv install does not include the system version 3.13.0.
+# System version 3.13.0. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
     do \
-      if [ "$VER" = "3.12.7" ]  ; then \
+      if [ "$VER" = "3.13.0" ]  ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.11.10" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.11.10" ] || [ "$VER" = "3.12.7" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \


### PR DESCRIPTION
pythonの3.12/3.13を追加しました。

下記をdockerhubにpushしています。
conchoid/docker-pyenv:v2.4.15-1-3.11-bookworm
conchoid/docker-pyenv:v2.4.15-1-3.11-bullseye
conchoid/docker-pyenv:v2.4.15-1-3.11-buster

conchoid/docker-pyenv:v2.4.13-1-3.12-bullseye
conchoid/docker-pyenv:v2.4.13-1-3.12-bookworm

conchoid/docker-pyenv:v2.4.13-1-3.13-bullseye
conchoid/docker-pyenv:v2.4.13-1-3.13-bookworm

