### PR TITLE
Update pyenv version and pip / peotry

### DIFF
--- a/3.11-bookworm/Dockerfile
+++ b/3.11-bookworm/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11.10-slim-bookworm
 
-ENV PYENV_ROOT /opt/pyenv
-ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
@@ -17,18 +17,18 @@ RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt
     && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
     && rm -f /etc/apt/sources.list.d/bionic-security.list
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
-ENV ROCRO_POETRY_VERSION="1.5.1"
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="25.0"
+ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.4.15" \
+RUN PYENV_VERSION="v2.5.1" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && PYTHON_BUILD_VERSION="c9514d8e8ec7db4b24085d697081fc8e243d5e53" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -37,11 +37,11 @@ RUN PYENV_VERSION="v2.4.15" \
     && cd "$PYENV_PIP_MIGRATE_DIR" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION"
 
-# NOTE: pyenv install does not include the system version 3.11.10.
-# System version 3.11.10. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
+# NOTE: pyenv install does not include the system version 3.11.11.
+# System version 3.11.11. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.11" "3.12.8" "3.13.1"; \
     do \
-      if [ "$VER" = "3.11.10" ] ; then \
+      if [ "$VER" = "3.11.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.11-bookworm/Dockerfile
+++ b/3.11-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.10-slim-bookworm
+FROM python:3.11.11-slim-bookworm
 
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -20,15 +20,15 @@ RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="25.0"
+ENV ROCRO_PYTHON_PIP_VERSION="25.0.1"
 ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.5.1" \
+RUN PYENV_VERSION="v2.5.4" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="c9514d8e8ec7db4b24085d697081fc8e243d5e53" \
+    && PYTHON_BUILD_VERSION="67f474d3e30dda469a6e181a0de0657176587c46" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -39,13 +39,13 @@ RUN PYENV_VERSION="v2.5.1" \
 
 # NOTE: pyenv install does not include the system version 3.11.11.
 # System version 3.11.11. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.11" "3.12.8" "3.13.1"; \
+RUN for VER in "3.8.20" "3.9.21" "3.10.16" "3.11.11" "3.12.9" "3.13.2"; \
     do \
       if [ "$VER" = "3.11.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ] || [ "$VER" = "3.13.0" ]; then \
+      elif [ "$VER" = "3.10.16" ] || [ "$VER" = "3.12.9" ] || [ "$VER" = "3.13.2" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.11-bullseye/Dockerfile
+++ b/3.11-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.10-slim-bullseye
+FROM python:3.11.11-slim-bullseye
 
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -20,15 +20,15 @@ RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="25.0"
+ENV ROCRO_PYTHON_PIP_VERSION="25.0.1"
 ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.5.1" \
+RUN PYENV_VERSION="v2.5.4" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="c9514d8e8ec7db4b24085d697081fc8e243d5e53" \
+    && PYTHON_BUILD_VERSION="67f474d3e30dda469a6e181a0de0657176587c46" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -39,13 +39,13 @@ RUN PYENV_VERSION="v2.5.1" \
 
 # NOTE: pyenv install does not include the system version 3.11.11.
 # System version 3.11.11. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.11" "3.12.8" "3.13.1"; \
+RUN for VER in "3.8.20" "3.9.21" "3.10.16" "3.11.11" "3.12.9" "3.13.2"; \
     do \
       if [ "$VER" = "3.11.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ] || [ "$VER" = "3.13.0" ]; then \
+      elif [ "$VER" = "3.10.16" ] || [ "$VER" = "3.12.9" ] || [ "$VER" = "3.13.2" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.11-bullseye/Dockerfile
+++ b/3.11-bullseye/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11.10-slim-bullseye
 
-ENV PYENV_ROOT /opt/pyenv
-ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
@@ -17,18 +17,18 @@ RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt
     && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
     && rm -f /etc/apt/sources.list.d/bionic-security.list
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
-ENV ROCRO_POETRY_VERSION="1.5.1"
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="25.0"
+ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.4.15" \
+RUN PYENV_VERSION="v2.5.1" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && PYTHON_BUILD_VERSION="c9514d8e8ec7db4b24085d697081fc8e243d5e53" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -37,11 +37,11 @@ RUN PYENV_VERSION="v2.4.15" \
     && cd "$PYENV_PIP_MIGRATE_DIR" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION"
 
-# NOTE: pyenv install does not include the system version 3.11.10.
-# System version 3.11.10. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
+# NOTE: pyenv install does not include the system version 3.11.11.
+# System version 3.11.11. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.11" "3.12.8" "3.13.1"; \
     do \
-      if [ "$VER" = "3.11.10" ] ; then \
+      if [ "$VER" = "3.11.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.11-buster/Dockerfile
+++ b/3.11-buster/Dockerfile
@@ -1,25 +1,25 @@
 FROM conchoid/debian-buster:python-3.11.10
 
-ENV PYENV_ROOT /opt/pyenv
-ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
 RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
     && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
     && rm -f /etc/apt/sources.list.d/bionic-security.list
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
-ENV ROCRO_POETRY_VERSION="1.5.1"
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="25.0"
+ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.4.15" \
+RUN PYENV_VERSION="v2.5.1" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
+    && PYTHON_BUILD_VERSION="c9514d8e8ec7db4b24085d697081fc8e243d5e53" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -28,15 +28,15 @@ RUN PYENV_VERSION="v2.4.15" \
     && cd "$PYENV_PIP_MIGRATE_DIR" \
     && git checkout -q "$PYENV_PIP_MIGRATE_VERSION"
 
-# NOTE: pyenv install does not include the system version 3.11.10.
-# System version 3.11.10. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7" "3.13.0"; \
+# NOTE: pyenv install does not include the system version 3.11.11.
+# System version 3.11.11. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.11" "3.12.8" "3.13.1"; \
     do \
-      if [ "$VER" = "3.11.10" ] ; then \
+      if [ "$VER" = "3.11.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.7" ] || [ "$VER" = "3.13.0" ]; then \
+      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.8" ] || [ "$VER" = "3.13.1" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \

--- a/3.11-buster/Dockerfile
+++ b/3.11-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM conchoid/debian-buster:python-3.11.10
+FROM conchoid/debian:buster-python-3.11.11
 
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -11,15 +11,15 @@ RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="25.0"
+ENV ROCRO_PYTHON_PIP_VERSION="25.0.1"
 ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.5.1" \
+RUN PYENV_VERSION="v2.5.4" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="c9514d8e8ec7db4b24085d697081fc8e243d5e53" \
+    && PYTHON_BUILD_VERSION="67f474d3e30dda469a6e181a0de0657176587c46" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \
@@ -30,13 +30,13 @@ RUN PYENV_VERSION="v2.5.1" \
 
 # NOTE: pyenv install does not include the system version 3.11.11.
 # System version 3.11.11. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.11" "3.12.8" "3.13.1"; \
+RUN for VER in "3.8.20" "3.9.21" "3.10.16" "3.11.11" "3.12.9" "3.13.2"; \
     do \
       if [ "$VER" = "3.11.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.12.8" ] || [ "$VER" = "3.13.1" ]; then \
+      elif [ "$VER" = "3.10.16" ] || [ "$VER" = "3.12.9" ] || [ "$VER" = "3.13.2" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \


### PR DESCRIPTION
pyenv / pip / poetryのversionを更新しました。

下記タグ名でdocker hubにpushしています。
conchoid/docker-pyenv:v2.5.4-1-3.11-bookworm
conchoid/docker-pyenv:v2.5.4-1-3.11-bullseye
conchoid/docker-pyenv:v2.5.4-1-3.11-buster

