### PR TITLE
Add python 3.12.11

### DIFF
--- a/3.12-bullseye/Dockerfile
+++ b/3.12-bullseye/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.12.7-slim-bullseye
+FROM python:3.12.11-slim-bullseye
 
-ENV PYENV_ROOT /opt/pyenv
-ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
 RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
@@ -17,13 +17,13 @@ RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt
     && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
     && rm -f /etc/apt/sources.list.d/bionic-security.list
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV ROCRO_PYTHON_PIP_VERSION="23.1.2"
-ENV ROCRO_POETRY_VERSION="1.5.1"
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV ROCRO_PYTHON_PIP_VERSION="24.3.1"
+ENV ROCRO_POETRY_VERSION="1.8.5"
 
-RUN PYENV_VERSION="v2.4.13" \
+RUN PYENV_VERSION="v2.6.3" \
     && mkdir -p "$PYENV_ROOT" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
@@ -35,18 +35,17 @@ RUN PYENV_VERSION="v2.4.13" \
     && PYENV_PIP_MIGRATE_DIR="$PYENV_ROOT/plugins/pyenv-pip-migrate" \
     && git clone https://github.com/pyenv/pyenv-pip-migrate.git "$PYENV_PIP_MIGRATE_DIR" \
     && cd "$PYENV_PIP_MIGRATE_DIR" \
-    && git checkout -q "$PYENV_PIP_MIGRATE_VERSION" \
-    && rm -r "$PYENV_ROOT/.git" && rm -rf " $PYENV_PIP_MIGRATE_DIR/.git"
+    && git checkout -q "$PYENV_PIP_MIGRATE_VERSION"
 
-# NOTE: pyenv install does not include the system version 3.12.7.
-# System version 3.12.7. uses a symbolic link in /usr/local/.
-RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
+# NOTE: pyenv install does not include the system version 3.12.11.
+# System version 3.12.11. uses a symbolic link in /usr/local/.
+RUN for VER in "3.8.20" "3.9.23" "3.10.18" "3.11.13" "3.12.11" "3.13.5"; \
     do \
-      if [ "$VER" = "3.12.7" ]  ; then \
+      if [ "$VER" = "3.12.11" ] ; then \
         ln -sf "/usr/local/" "${PYENV_ROOT}/versions/${VER}" \
         && apt-get update && apt-get install -y libssl-dev \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
-      elif [ "$VER" = "3.10.15" ] || [ "$VER" = "3.11.10" ]; then \
+      elif [ "$VER" = "3.10.18" ] || [ "$VER" = "3.11.13" ] || [ "$VER" = "3.13.5" ]; then \
         apt-get update && apt-get install -y libssl-dev \
         && pyenv install $VER \
         && PYENV_VERSION="$VER" pip install --upgrade pip=="$ROCRO_PYTHON_PIP_VERSION" six poetry=="$ROCRO_POETRY_VERSION"; \
@@ -56,4 +55,4 @@ RUN for VER in "3.8.20" "3.9.20" "3.10.15" "3.11.10" "3.12.7"; \
       fi \
       && pyenv rehash ; \
     done \
-    && pyenv global system $(pyenv versions --bare | sort -rV | xargs)
+    && pyenv global system

--- a/3.12-buster/Dockerfile
+++ b/3.12-buster/Dockerfile
@@ -1,16 +1,7 @@
-FROM python:3.12.11-slim-bookworm
+FROM conchoid/debian:buster-python-3.12.11
 
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-
-RUN apt-get update \
-    && apt-get install -y --allow-unauthenticated \
-      gcc g++ make build-essential zlib1g-dev libbz2-dev \
-      libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
-      locales \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \
@@ -28,7 +19,7 @@ RUN PYENV_VERSION="v2.6.3" \
     && git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
     && cd "$PYENV_ROOT" \
     && git checkout -q "$PYENV_VERSION" \
-    && PYTHON_BUILD_VERSION="798d21e0ca350be54df95532bd904b391f4ca277" \
+    && PYTHON_BUILD_VERSION="95917cb753638cd1b9acc1d2b2c4686d8a934d10" \
     && cd "$PYENV_ROOT/plugins" \
     && git checkout -q "$PYTHON_BUILD_VERSION" ./python-build \
     && PYENV_PIP_MIGRATE_VERSION="1ddc347b5db9895927ea09bbe9d0e2de8ebf902b" \


### PR DESCRIPTION
ベースイメージを3.12.11へ更新。

Pipのバージョンも更新しています。(3.8が利用できる最新の24.3.1)

docker hubには下記のタグで登録しています。

```
conchoid/docker-pyenv:v2.6.3-1-3.12-bookworm
conchoid/docker-pyenv:v2.6.3-1-3.12-bullseye
conchoid/docker-pyenv:v2.6.3-1-3.12-buster
```