### PR TITLE
Use conchoid/debian:trixie-slim for git-lfs (CVE-2025-68121)

### DIFF
--- a/3.12-bookworm/Dockerfile
+++ b/3.12-bookworm/Dockerfile
@@ -9,10 +9,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       gcc g++ make build-essential zlib1g-dev libbz2-dev \
       libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev \
-      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev git git-lfs gnupg \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev git gnupg \
       locales libssl-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+RUN git lfs install
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en

--- a/3.12-bullseye/Dockerfile
+++ b/3.12-bullseye/Dockerfile
@@ -9,10 +9,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       gcc-10 g++-10 make build-essential zlib1g-dev libbz2-dev \
       libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev \
-      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev git git-lfs gnupg \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev git gnupg \
       locales libssl-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+RUN git lfs install
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en

--- a/3.12-trixie/Dockerfile
+++ b/3.12-trixie/Dockerfile
@@ -1,16 +1,4 @@
 # Docker Hub: conchoid/docker-pyenv:v2.6.27-2-3.12.13-trixie
-# Build git-lfs using Go 1.26.2
-FROM golang:1.26.2-trixie AS git-lfs-builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-
-RUN git clone --depth 1 --branch v3.6.0 https://github.com/git-lfs/git-lfs.git /src/git-lfs \
-    && cd /src/git-lfs \
-    && go get golang.org/x/crypto@latest \
-    && go get golang.org/x/net@latest \
-    && go mod tidy \
-    && go build -o bin/git-lfs
-
 FROM python:3.12.13-slim-trixie
 
 ENV PYENV_ROOT=/opt/pyenv
@@ -26,7 +14,7 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-COPY --from=git-lfs-builder /src/git-lfs/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 RUN git lfs install
 
 ENV LANG=en_US.UTF-8

--- a/3.13-bookworm/Dockerfile
+++ b/3.13-bookworm/Dockerfile
@@ -8,10 +8,13 @@ RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
       gcc g++ make build-essential zlib1g-dev libbz2-dev \
       libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git gnupg \
       locales \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+RUN git lfs install
 
 RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \

--- a/3.13-bullseye/Dockerfile
+++ b/3.13-bullseye/Dockerfile
@@ -8,10 +8,13 @@ RUN apt-get update \
     && apt-get install -y --allow-unauthenticated \
       gcc-10 g++-10 make build-essential zlib1g-dev libbz2-dev \
       libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git git-lfs gnupg \
+      xz-utils unixodbc-dev tk-dev libffi-dev liblzma-dev python3-openssl git gnupg \
       locales \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
+RUN git lfs install
 
 RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 \

--- a/3.13-trixie/Dockerfile
+++ b/3.13-trixie/Dockerfile
@@ -1,16 +1,4 @@
 # Docker Hub: conchoid/docker-pyenv:v2.6.27-1-3.13.13-trixie
-# Build git-lfs using Go 1.26.2
-FROM golang:1.26.2-trixie AS git-lfs-builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-
-RUN git clone --depth 1 --branch v3.6.0 https://github.com/git-lfs/git-lfs.git /src/git-lfs \
-    && cd /src/git-lfs \
-    && go get golang.org/x/crypto@latest \
-    && go get golang.org/x/net@latest \
-    && go mod tidy \
-    && go build -o bin/git-lfs
-
 FROM python:3.13.11-trixie
 
 ENV PYENV_ROOT=/opt/pyenv
@@ -25,7 +13,7 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-COPY --from=git-lfs-builder /src/git-lfs/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 RUN git lfs install
 
 RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \

--- a/3.14-trixie/Dockerfile
+++ b/3.14-trixie/Dockerfile
@@ -1,16 +1,4 @@
 # Docker Hub: conchoid/docker-pyenv:v2.6.27-1-3.14.4-trixie
-# Build git-lfs using Go 1.26.2
-FROM golang:1.26.2-trixie AS git-lfs-builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-
-RUN git clone --depth 1 --branch v3.6.0 https://github.com/git-lfs/git-lfs.git /src/git-lfs \
-    && cd /src/git-lfs \
-    && go get golang.org/x/crypto@latest \
-    && go get golang.org/x/net@latest \
-    && go mod tidy \
-    && go build -o bin/git-lfs
-
 FROM python:3.14.2-trixie
 
 ENV PYENV_ROOT=/opt/pyenv
@@ -25,7 +13,7 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-COPY --from=git-lfs-builder /src/git-lfs/bin/git-lfs /usr/local/bin/git-lfs
+COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 RUN git lfs install
 
 RUN echo "deb [trusted=yes] http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \


### PR DESCRIPTION
## Summary

- Replace per-Dockerfile multi-stage builder stages and `apt-get install git-lfs` with `COPY --from=conchoid/debian:trixie-slim /usr/local/bin/git-lfs` across all 7 Dockerfiles
- `conchoid/debian:trixie-slim` provides git-lfs v3.6.0 compiled with Go 1.26.2, avoiding CVE-2025-68121 (Go 1.24.4 crypto/tls)
- Simplifies each Dockerfile: no more ~12-line builder stage per file

## Affected files

| File | Change |
|------|--------|
| `3.12-trixie` | Remove builder stage → `COPY --from=conchoid/debian:trixie-slim` |
| `3.13-trixie` | Remove builder stage → `COPY --from=conchoid/debian:trixie-slim` |
| `3.14-trixie` | Remove builder stage → `COPY --from=conchoid/debian:trixie-slim` |
| `3.12-bookworm` | Remove `apt-get install git-lfs` → `COPY --from=conchoid/debian:trixie-slim` |
| `3.12-bullseye` | Remove `apt-get install git-lfs` → `COPY --from=conchoid/debian:trixie-slim` |
| `3.13-bookworm` | Remove `apt-get install git-lfs` → `COPY --from=conchoid/debian:trixie-slim` |
| `3.13-bullseye` | Remove `apt-get install git-lfs` → `COPY --from=conchoid/debian:trixie-slim` |

## Prerequisites

- `conchoid/debian:trixie-slim` must be available on Docker Hub (already pushed via conchoid/debian#5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)